### PR TITLE
When waiting the passcode skip additional informations if any.

### DIFF
--- a/pinentry-kwallet
+++ b/pinentry-kwallet
@@ -219,11 +219,12 @@ function getit {
 		io_s_out GETPIN
 		io_s_in resp
 		pw=
-		#XXX normally, read until OK|ERR
-		if [[ $resp = @(D )* ]]; then
-			pw=${resp#D }
-			io_s_in resp
-		fi
+		while [[ $resp != @(OK|ERR)@(| *) ]]; do
+		    if [[ $resp = @(D )* ]]; then
+			    pw=${resp#D }
+		    fi
+            io_s_in resp
+        done
 		[[ $resp = OK@(| *) ]] && tw=1
 	fi
 	(( tw && !blst )) && if kwalletcli_getpin -q -b \


### PR DESCRIPTION
This is a fix to use pinentry-kwallet with rather new pinentry-qt which tells whether the passcode is from input or a cached one before sending the actual passcode.
It yet still ignores the 'allow-external-cache' option and try to store in kwallet always.


I understand this is not the official cvs but just a copy. But the mailing list of MirOS was unreachable and email has bounced so let me send a pull request here. 
